### PR TITLE
feat(addon/components/paper-card-image): migrates to tagless native class.

### DIFF
--- a/addon/components/paper-card-image.hbs
+++ b/addon/components/paper-card-image.hbs
@@ -1,0 +1,1 @@
+<img class="md-card-image" alt={{@alt}} src={{@src}} title={{@title}} ...attributes>

--- a/addon/components/paper-card-image.js
+++ b/addon/components/paper-card-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components, prettier/prettier */
+/* eslint-disable ember/no-classic-components */
 /**
  * @module ember-paper
  */
@@ -8,8 +8,6 @@ import Component from '@ember/component';
  * @class PaperCardImage
  * @extends Ember.Component
  */
-export default Component.extend({
-  tagName: 'img',
-  classNames: ['md-card-image'],
-  attributeBindings: ['src', 'title', 'alt']
-});
+export default class PaperCardImage extends Component {
+  tagName = '';
+}


### PR DESCRIPTION
keeps api compatibility by taking in alt, src and title as params.